### PR TITLE
Garbage tolerance patch: simple error handling on CScript load

### DIFF
--- a/CScript.cs
+++ b/CScript.cs
@@ -11,6 +11,7 @@ using System.Net;
 using System.Reflection.Emit;
 using System.Text;
 using System.Windows.Documents;
+using System.Windows.Forms;
 
 namespace GorkhonScriptEditor
 {
@@ -2294,6 +2295,8 @@ namespace GorkhonScriptEditor
 
             InstructionBlockOffset = 0;
 
+            int instructionsRead = 0;
+
             //Parsing script binary starts here
 
             //Global variables block
@@ -2513,7 +2516,11 @@ namespace GorkhonScriptEditor
             {
                 byte opcode = binData[offset];
                 offset += 2;
+                instructionsRead++;
                 listInstructions.Add(createInstruction(opcode, i, (UInt32)offset,ref this.offset,ref this.binaryData));
+            }
+            if (instructionsRead != numInstructions) {
+                MessageBox.Show("Invalid instruction count: got " + instructionsRead + " but expected " + numInstructions, "Warning", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
             }
 
             //Flow graph (not sure if still necessary in the current iteration)

--- a/CScript.cs
+++ b/CScript.cs
@@ -83,7 +83,7 @@ namespace GorkhonScriptEditor
 
         public List<string> stringRepresentation;
 
-        public int numFunctions;
+        public UInt32 numFunctions;
 
         //#TODO: refactor function adding / binary reconstruction
 

--- a/CScript.cs
+++ b/CScript.cs
@@ -2514,13 +2514,17 @@ namespace GorkhonScriptEditor
             //Create instruction list
             for (int i = 0; (i < numInstructions) && (offset < binData.Count()); i++)
             {
-                byte opcode = binData[offset];
-                offset += 2;
+                try {
+                    byte opcode = binData[offset];
+                    offset += 2;
+                    listInstructions.Add(createInstruction(opcode, i, (UInt32)offset,ref this.offset,ref this.binaryData));
+                } catch (IndexOutOfRangeException x) {
+                    MessageBox.Show("Failed to parse instruction " + instructionsRead + " of " + numInstructions, "Error", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+                }
                 instructionsRead++;
-                listInstructions.Add(createInstruction(opcode, i, (UInt32)offset,ref this.offset,ref this.binaryData));
             }
             if (instructionsRead != numInstructions) {
-                MessageBox.Show("Invalid instruction count: got " + instructionsRead + " but expected " + numInstructions, "Warning", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+                MessageBox.Show("Wrong instruction count: got " + instructionsRead + " but expected " + numInstructions, "Warning", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
             }
 
             //Flow graph (not sure if still necessary in the current iteration)

--- a/CScript.cs
+++ b/CScript.cs
@@ -3,6 +3,7 @@ using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using CommunityToolkit.Mvvm.Messaging.Messages;
 using GorkhonScriptEditor.Instructions;
+using Microsoft.CodeAnalysis.Operations;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -2296,13 +2297,15 @@ namespace GorkhonScriptEditor
             InstructionBlockOffset = 0;
 
             int instructionsRead = 0;
+            string errorMessage = "";
 
             //Parsing script binary starts here
 
             if (binData.Length < 16) {
                 // Sanity check before we try to extract numGlobalVars
-                MessageBox.Show("File is too short to be a valid script: " + binData.Length + " bytes", "Critical error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                return false;
+                errorMessage = "File is too short to be a valid script: " + binData.Length + " bytes";
+                MessageBox.Show(errorMessage, "Critical error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                throw new ArgumentException(errorMessage);
             }
 
             //Global variables block
@@ -2310,8 +2313,9 @@ namespace GorkhonScriptEditor
             numGlobalVars = System.BitConverter.ToUInt32(binData.AsSpan<byte>(offset, 4));
             if (numGlobalVars < 0 | numGlobalVars > binData.Length) {
                 // Avoid possible infinite loop
-                MessageBox.Show("Invalid number of global variables: " + numGlobalVars, "Critical error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                return false;
+                errorMessage = "Invalid number of global variables: " + numGlobalVars;
+                MessageBox.Show(errorMessage, "Critical error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                throw new ArgumentException(errorMessage);
             }
             offset += 4;
 
@@ -2332,7 +2336,8 @@ namespace GorkhonScriptEditor
                         offset += varNameLength;
                     }
                     catch (ArgumentException) {
-                        MessageBox.Show("Failed to parse global variable #" + i + " of " + numGlobalVars, "Critical error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        errorMessage = "Failed to parse global variable #" + i + " of " + numGlobalVars;
+                        MessageBox.Show(errorMessage, "Critical error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                         break;
                     }
                 }
@@ -2353,8 +2358,9 @@ namespace GorkhonScriptEditor
                 stringBlockBytes = (new ArraySegment<byte>(binData, offset, stringBlockLength)).ToArray().ToList();
             } catch (ArgumentException)
             {
-                MessageBox.Show("Failed to parse string block of length " + stringBlockLength, "Critical error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                return false;
+                errorMessage = "Failed to parse string block of length " + stringBlockLength;
+                MessageBox.Show(errorMessage, "Critical error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                throw new ArgumentException(errorMessage);
                 // This error is unrecoverable; stop the loading process
             }
 

--- a/CScript.cs
+++ b/CScript.cs
@@ -2333,12 +2333,18 @@ namespace GorkhonScriptEditor
             }
 
             //String block
-            Span<byte> stringBlockLengthBin = binData.AsSpan<byte>(offset, 4);
-            stringBlockLength = System.BitConverter.ToInt32(stringBlockLengthBin);
-            offset += 4;
+            try {
+                Span<byte> stringBlockLengthBin = binData.AsSpan<byte>(offset, 4);
+                stringBlockLength = System.BitConverter.ToInt32(stringBlockLengthBin);
+                offset += 4;
 
-            stringBlockOffset = offset;
-            stringBlockBytes = (new ArraySegment<byte>(binData, offset, stringBlockLength)).ToArray().ToList();
+                stringBlockOffset = offset;
+                stringBlockBytes = (new ArraySegment<byte>(binData, offset, stringBlockLength)).ToArray().ToList();
+            } catch (ArgumentException x)
+            {
+                MessageBox.Show("Failed to parse string block of length " + stringBlockLength, "Critical error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return false;
+            }
 
             //Detecting separate strings
 

--- a/CScript.cs
+++ b/CScript.cs
@@ -2308,7 +2308,7 @@ namespace GorkhonScriptEditor
             //Global variables block
             offset = 0;
             numGlobalVars = System.BitConverter.ToUInt32(binData.AsSpan<byte>(offset, 4));
-            if (numGlobalVars < 0) {
+            if (numGlobalVars < 0 | numGlobalVars > binData.Length) {
                 // Avoid possible infinite loop
                 MessageBox.Show("Invalid number of global variables: " + numGlobalVars, "Critical error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;
@@ -2543,7 +2543,7 @@ namespace GorkhonScriptEditor
                     byte opcode = binData[offset];
                     offset += 2;
                     listInstructions.Add(createInstruction(opcode, i, (UInt32)offset,ref this.offset,ref this.binaryData));
-                } catch (IndexOutOfRangeException x) {
+                } catch (IndexOutOfRangeException) {
                     MessageBox.Show("Failed to parse instruction #" + instructionsRead + " of " + numInstructions, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                     // DO NOT abort: it's useful to see which instructions succeeded loading, if any
                 }

--- a/CScript.cs
+++ b/CScript.cs
@@ -2313,10 +2313,17 @@ namespace GorkhonScriptEditor
                 string varName = "N/A";
                 if (hasName)
                 {
-                    byte varNameLength = binData[offset];
-                    offset++;
-                    varName = System.Text.Encoding.UTF8.GetString(new ArraySegment<byte>(binData, offset, varNameLength).ToArray());
-                    offset += varNameLength;
+                    try
+                    {
+                        byte varNameLength = binData[offset];
+                        offset++;
+                        varName = System.Text.Encoding.UTF8.GetString(new ArraySegment<byte>(binData, offset, varNameLength).ToArray());
+                        offset += varNameLength;
+                    }
+                    catch (ArgumentException x) {
+                        MessageBox.Show("Failed to parse global variable #" + i + " of " + numGlobalVars, "Critical error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        break;
+                    }
                 }
                 CGlobalVar newVar = new(varType, varName);
                 newVar.ID = i.ToString();
@@ -2519,12 +2526,12 @@ namespace GorkhonScriptEditor
                     offset += 2;
                     listInstructions.Add(createInstruction(opcode, i, (UInt32)offset,ref this.offset,ref this.binaryData));
                 } catch (IndexOutOfRangeException x) {
-                    MessageBox.Show("Failed to parse instruction " + instructionsRead + " of " + numInstructions, "Error", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+                    MessageBox.Show("Failed to parse instruction #" + instructionsRead + " of " + numInstructions, "Critical error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
                 instructionsRead++;
             }
             if (instructionsRead != numInstructions) {
-                MessageBox.Show("Wrong instruction count: got " + instructionsRead + " but expected " + numInstructions, "Warning", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+                MessageBox.Show("Wrong instruction count: read " + instructionsRead + " instructions, but expected " + numInstructions, "Warning", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
             }
 
             //Flow graph (not sure if still necessary in the current iteration)

--- a/CScript.cs
+++ b/CScript.cs
@@ -2311,8 +2311,7 @@ namespace GorkhonScriptEditor
             //Global variables block
             offset = 0;
             numGlobalVars = System.BitConverter.ToUInt32(binData.AsSpan<byte>(offset, 4));
-            if (numGlobalVars < 0 | numGlobalVars > binData.Length) {
-                // Avoid possible infinite loop
+            if (numGlobalVars > binData.Length) {
                 errorMessage = "Invalid number of global variables: " + numGlobalVars;
                 MessageBox.Show(errorMessage, "Critical error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 throw new ArgumentException(errorMessage);
@@ -2428,11 +2427,11 @@ namespace GorkhonScriptEditor
             offset += stringBlockLength;
 
             //Collect function info
-            numFunctions = System.BitConverter.ToInt32(binData.AsSpan<byte>(offset, 4));
+            numFunctions = System.BitConverter.ToUInt32(binData.AsSpan<byte>(offset, 4));
             numFunctionsOffset = offset;
             offset += 4;
 
-            if (numFunctions < 0 | numFunctions > binData.Length)
+            if (numFunctions > binData.Length)
             {
                 errorMessage = "Invalid number of functions: " + numFunctions;
                 MessageBox.Show(errorMessage, "Critical error", MessageBoxButtons.OK, MessageBoxIcon.Error);
@@ -2549,9 +2548,8 @@ namespace GorkhonScriptEditor
             offset += 4;
             InstructionBlockOffset = offset;
 
-            if (numInstructions < 0 | numInstructions > binData.Length)
+            if (numInstructions > binData.Length)
             {
-                // Avoid possible infinite loop
                 errorMessage = "Invalid number of instructions: " + numInstructions;
                 MessageBox.Show(errorMessage, "Critical error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 throw new ArgumentException(errorMessage);

--- a/CScript.cs
+++ b/CScript.cs
@@ -2297,7 +2297,7 @@ namespace GorkhonScriptEditor
             InstructionBlockOffset = 0;
 
             int instructionsRead = 0;
-            string errorMessage = "";
+            string errorMessage = "Unknown error";
 
             //Parsing script binary starts here
 

--- a/CScript.cs
+++ b/CScript.cs
@@ -2431,6 +2431,14 @@ namespace GorkhonScriptEditor
             numFunctions = System.BitConverter.ToInt32(binData.AsSpan<byte>(offset, 4));
             numFunctionsOffset = offset;
             offset += 4;
+
+            if (numFunctions < 0 | numFunctions > binData.Length)
+            {
+                errorMessage = "Invalid number of functions: " + numFunctions;
+                MessageBox.Show(errorMessage, "Critical error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                throw new ArgumentException(errorMessage);
+            }
+
             for (int i = 0; i < numFunctions; i++)
             {
                 byte length = binaryData[offset];
@@ -2539,8 +2547,15 @@ namespace GorkhonScriptEditor
             numInstructions = System.BitConverter.ToUInt32(binData.AsSpan<byte>(offset, 4));
             numInstructionsOffset = (uint)offset;
             offset += 4;
-
             InstructionBlockOffset = offset;
+
+            if (numInstructions < 0 | numInstructions > binData.Length)
+            {
+                // Avoid possible infinite loop
+                errorMessage = "Invalid number of instructions: " + numInstructions;
+                MessageBox.Show(errorMessage, "Critical error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                throw new ArgumentException(errorMessage);
+            }
 
             //Create instruction list
             for (int i = 0; (i < numInstructions) && (offset < binData.Count()); i++)

--- a/ViewModel/CMainWindowViewModel.cs
+++ b/ViewModel/CMainWindowViewModel.cs
@@ -24,7 +24,8 @@ namespace GorkhonScriptEditor.ViewModel
         public enum ProgramState
         {
             Opened,
-            Loaded
+            Loaded,
+            Broken
         }
 
         [ObservableProperty]
@@ -209,19 +210,36 @@ namespace GorkhonScriptEditor.ViewModel
 
                 WindowTitle = "Gorkhon Script Editor: " + openFileDialog.FileName;
 
-                MainScript = new CScript(binaryData);
+                try
+                {
+                    MainScript = new CScript(binaryData);
 
-                //Perhaps find a more elegant solution
-                MainScript.ScriptName = openFileDialog.FileName.Split('\\')[^1];
+                    //Perhaps find a more elegant solution
+                    MainScript.ScriptName = openFileDialog.FileName.Split('\\')[^1];
 
-                state = ProgramState.Loaded;
-                InterfaceEnabled = true;
+                    state = ProgramState.Loaded;
+                    InterfaceEnabled = true;
 
-                //Temporarily disabling this
-                //LineOfInterest = MainScript.Lines[0];
+                    //Temporarily disabling this
+                    //LineOfInterest = MainScript.Lines[0];
 
-                //Save a backup file here
-                System.IO.File.WriteAllBytes(openFileDialog.FileName + ".gse_bak", binaryData);
+                    //Save a backup file here
+                    System.IO.File.WriteAllBytes(openFileDialog.FileName + ".gse_bak", binaryData);
+
+                } catch (ArgumentException)
+                {
+                    // If the script failed to load, do not enable the interface
+                    WindowTitle = "Gorkhon Script Editor: failed to load " + openFileDialog.FileName;
+                    // TODO: somehow display exception message in the main window
+
+                    state = ProgramState.Broken;
+                    InterfaceEnabled = false;
+                    // Workaround - ideally we would close the open script instead, once
+                    // "close current script" functionality is added. Need to ensure that
+                    // a load failure doesn't cause unintended behavior if the user resumes
+                    // interacting with the previously successfully loaded script.
+                }
+
             }
         }
 


### PR DESCRIPTION
Adds a couple of try/catch blocks in CScript.UpdateFromBinary to avert the most common GSE crashes when loading a broken script. 

Features in this pull request:
* Avoid crash on empty file (strictly, on scripts with less than 16 bytes, pertaining to the four required ints in a header - this should be adjusted to include the minimum length of the task/event section, once it is documented)
* Avoid one type of crash on unparsable string block (where block size passes the end of the binary data)
* Avoid crash if instructions are sought past the end of the binary data
* QoL: warn user if the instruction count does not match number of instructions read
* Avoid potential infinite loops if numGlobalVars, numFunctions or numInstructions are negative; raise error if there are implausibly many of them (if numXYZ > length of the binary data)

All types of error and warning display a MessageBox to the user containing specific information about the offending byte/variable/etc. Critical (unrecoverable) errors throw an ArgumentException with the same message, which is handled by the MainWindowViewModel.

In the case of a critical error, the user interface must be turned off. Because GSE does not support clearing/removing a currently loaded script, this is a workaround to ensure there is no cross-contamination of a previously loaded script in the display, if a new one fails partway through the loading process. I've added a "Broken" ProgramState enum whose only function at the moment is to indicate "not opened or loaded"; was not certain if this is required, input welcome. Load failure is indicated in the main window by switching the window title to "failed to load FILENAME" - ideally the error message passed with the ArgumentException, which is currently unused, would be displayed in the main panel once we can get rid of the previous file there.

![criterror](https://github.com/adc-ax/GorkhonScriptEditor/assets/26174805/6d5fbba1-85de-41cd-88df-48f783dc710c)
![warn](https://github.com/adc-ax/GorkhonScriptEditor/assets/26174805/34decb5e-620c-43b7-891f-ccae3b26264c)
